### PR TITLE
Converted (BCF2 0 Technical Documentation.docx) to markdown

### DIFF
--- a/Documentation/BCF2 0 Technical Documentation.md
+++ b/Documentation/BCF2 0 Technical Documentation.md
@@ -7,7 +7,7 @@ Authors:
 * Lassi Lifländer, Tekla (BCF 1.0)
 * Klaus Linhard, IABI (BCF 2.0)
 
-## Terms and Abbreviations
+### Terms and Abbreviations
 
 
 


### PR DESCRIPTION
Converted (BCF2 0 Technical Documentation.docx) to markdown
