### PR TITLE
Markup schema fix for recurring elements

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -146,12 +146,12 @@ ReferencedDocument | Yes | URI to document. <br> IsExternal=false  “..\example
 Description | Yes | Description of the document
 
 
-### RelatedTopics (optional)
+### RelatedTopic (optional)
 Relation between topics (Clash -> PfV -> Opening)
 
-Element/Attribute | Optional | Description |  
+Attribute | Optional | Description |  
 :-----------|:------------|:------------
-RelatedTopics/GUID | Yes | List of GUIDs of the referenced topics.
+Guid | Yes | Guid of the referenced topic.
 
 
 ### Comment

--- a/Schemas/markup.xsd
+++ b/Schemas/markup.xsd
@@ -81,7 +81,7 @@
 					<xs:attributeGroup ref="DocumentReference"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="RelatedTopics" minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="RelatedTopic" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:attribute name="Guid" type="Guid" use="required"/>
 				</xs:complexType>

--- a/Schemas/markup.xsd
+++ b/Schemas/markup.xsd
@@ -68,9 +68,9 @@
 			<xs:element name="ModifiedAuthor" type="UserIdType" minOccurs="0"/>
 			<xs:element name="AssignedTo" type="UserIdType" minOccurs="0"/>
 			<xs:element name="Description" type="xs:string" minOccurs="0"/>
-			<xs:element name="BimSnippet" type="BimSnippet" minOccurs="0"/>
+			<xs:element name="BimSnippet" type="BimSnippet" minOccurs="0" maxOccurs="unbounded"/>
 			<!-- Name of the file in the topic folder or url -->
-			<xs:element name="DocumentReferences" minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="DocumentReference" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>
 						<!-- Name of the file in the topic folder or url -->

--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -31,7 +31,7 @@
 					</xs:complexType>
 				</xs:element>
 				<!-- ISG Jira issue BCF-17: Add support for text in the viewpoints -->
-				<xs:element name="Bitmaps" minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="Bitmap" minOccurs="0" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="Bitmap" type="BitmapFormat"/>


### PR DESCRIPTION
BIMSnippet to unbounded, remove plural from DocumentReferences and Relatedtopics element names. Maybe this is the original intent?