### PR TITLE
Update Viewpoint schema to reflect latest decisions regarding size optimization

### DIFF
--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -7,17 +7,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="Components" minOccurs="0">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="Component" type="Component" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="DefaultVisibilityComponents" type="xs:boolean" default="true"/>
-						<xs:attribute name="DefaultVisibilitySpaces" type="xs:boolean" default="true"/>
-						<xs:attribute name="DefaultVisibilityOpenings" type="xs:boolean" default="true"/>
-						<xs:attribute name="DefaultVisibilitySpaceBoundaries" type="xs:boolean" default="true"/>
-					</xs:complexType>
-				</xs:element>
+				<xs:element name="Components" type="Components" minOccurs="0"/>
 				<xs:element name="OrthogonalCamera" type="OrthogonalCamera" minOccurs="0"/>
 				<xs:element name="PerspectiveCamera" type="PerspectiveCamera" minOccurs="0"/>
 				<xs:element name="Lines" minOccurs="0">
@@ -97,19 +87,66 @@
 			<xs:maxInclusive value="60"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="Components">
+		<xs:sequence>
+			<!-- Components with relevance to the viewpoint. They should be displayed highlighted or selected in a viewer -->
+			<xs:element name="RelevantComponents" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Component" type="Component" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Visibility" type="ComponentsVisibility" minOccurs="1" />
+			<xs:element name="Coloring" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Color" type="ComponentColoring" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ComponentsVisibility">
+		<xs:sequence>
+			<xs:element name="Exceptions" minOccurs="0">
+				<!-- List Components that are different than the DefaultVisibility. E.g. if DefaultVisibility = false then list
+					 Components that should be visible -->
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Component" type="Component" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>	
+		</xs:sequence>
+		<xs:attribute name="DefaultVisibility" type="xs:boolean"/>
+		<xs:attribute name="SpacesOn" type="xs:boolean"/>
+		<xs:attribute name="SpaceBoundariesOn" type="xs:boolean"/>
+		<xs:attribute name="OpeningsOn" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ComponentColoring">
+		<xs:sequence>
+			<xs:element name="Component" type="Component" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute ref="Color"/>
+	</xs:complexType>
 	<xs:complexType name="Component">
 		<xs:sequence>
 			<xs:element name="OriginatingSystem" type="xs:string" minOccurs="0"/>
 			<xs:element name="AuthoringToolId" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute ref="IfcGuid"/>
-		<xs:attribute name="Selected" type="xs:boolean"/>
-		<xs:attribute name="Visible" type="xs:boolean" default="true"/>
-		<xs:attribute name="Color" type="xs:hexBinary"/>
 		<!-- ISG Jira Issue BCF-14 -->
 	</xs:complexType>
+	<xs:attribute name="Color">
+		<xs:simpleType>
+			<xs:restriction base="xs:normalizedString">
+			<!-- Should either match 3 or 4 hex bytes , e.g. "FF00FF" or "FF00FF99" -->
+				<xs:pattern value="[0-9,A-F]{6}([0-9,A-F]{2})?"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:attribute>
 	<xs:attribute name="IfcGuid">
-		<!-- 3dKX8qrKT4nfaFKnVwXlca -->
 		<xs:simpleType>
 			<xs:restriction base="xs:normalizedString">
 				<xs:length value="22"/>


### PR DESCRIPTION
This should result in viewpoints that look like this:

```xml
<VisualizationInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Guid="8dc86298-9737-40b4-a448-98a9e953293a">
  <Components>
    <RelevantComponents>
      <Component IfcGuid="0Gl71cVurFn8bxAOox6M4X" />
    </RelevantComponents>
    <Visibility DefaultVisibility="true" SpacesOn="true" SpaceBoundariesOn="true" OpeningsOn="true">
      <Exceptions>
        <Component IfcGuid="0Gl71cVurFn8bxAOox6M4X" />
        <Component IfcGuid="23Zwlpd71EyvHlH6OZ77nK" />
        <Component IfcGuid="3DvyPxGIn8qR0KDwbL_9r1" />
      </Exceptions>
    </Visibility>
    <Coloring>
      <Color Color="FF00FF">
        <Component IfcGuid="0fdpeZZEX3FwJ7x0ox5kzF" />
        <Component IfcGuid="1OpjQ1Nlv4sQuTxfUC_8zS" />
      </Color>                                        
      <Color Color="FF00FF99">                        
        <Component IfcGuid="0cSRUx$EX1NRjqiKcYQ$a0" />
        <Component IfcGuid="1jQQiGIAnFzxOUzrdmJYDS" />
      </Color>
    </Coloring>
  </Components>
</VisualizationInfo>