### PR TITLE
187 Colour hexes should probably allow both uppercase and lowercase

### DIFF
--- a/Schemas/markup.xsd
+++ b/Schemas/markup.xsd
@@ -143,7 +143,7 @@
 	<xs:simpleType name="IfcGuid">
 		<xs:restriction base="xs:string">
 			<xs:length value="22"/>
-			<xs:pattern value="[0-9,A-Z,a-z,_$]*"/>
+			<xs:pattern value="[0-9A-Za-z_$]*"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:attributeGroup name="FileAttributes">

--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -119,7 +119,7 @@
 						<xs:element name="Component" type="Component" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
-			</xs:element>	
+			</xs:element>
 		</xs:sequence>
 		<xs:attribute name="DefaultVisibility" type="xs:boolean"/>
 	</xs:complexType>
@@ -151,8 +151,8 @@
 	<xs:attribute name="Color">
 		<xs:simpleType>
 			<xs:restriction base="xs:normalizedString">
-			<!-- Should either match 3 or 4 hex bytes , e.g. "FF00FF" or "FF00FF99" -->
-				<xs:pattern value="[0-9,A-F]{6}([0-9,A-F]{2})?"/>
+				<!-- Should either match 3 or 4 hex bytes , e.g. "FF00FF" or "FF00FF99" -->
+				<xs:pattern value="[0-9,A-Fa-f]{6}([0-9,A-Fa-f]{2})?"/>
 			</xs:restriction>
 		</xs:simpleType>
 	</xs:attribute>

--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -152,7 +152,7 @@
 		<xs:simpleType>
 			<xs:restriction base="xs:normalizedString">
 				<!-- Should either match 3 or 4 hex bytes , e.g. "FF00FF" or "FF00FF99" -->
-				<xs:pattern value="[0-9,A-Fa-f]{6}([0-9,A-Fa-f]{2})?"/>
+				<xs:pattern value="[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?"/>
 			</xs:restriction>
 		</xs:simpleType>
 	</xs:attribute>
@@ -160,7 +160,7 @@
 		<xs:simpleType>
 			<xs:restriction base="xs:normalizedString">
 				<xs:length value="22"/>
-				<xs:pattern value="[0-9,A-Z,a-z,_$]*"/>
+				<xs:pattern value="[0-9A-Za-z_$]*"/>
 			</xs:restriction>
 		</xs:simpleType>
 	</xs:attribute>

--- a/Test Cases/v2.1/Markup/MaximumInformation/unzipped/markup.xsd
+++ b/Test Cases/v2.1/Markup/MaximumInformation/unzipped/markup.xsd
@@ -143,7 +143,7 @@
 	<xs:simpleType name="IfcGuid">
 		<xs:restriction base="xs:string">
 			<xs:length value="22"/>
-			<xs:pattern value="[0-9,A-Z,a-z,_$]*"/>
+			<xs:pattern value="[0-9A-Za-z_$]*"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:attributeGroup name="FileAttributes">

--- a/Test Cases/v2/Markup/MaximumInformation/markup.xsd
+++ b/Test Cases/v2/Markup/MaximumInformation/markup.xsd
@@ -139,7 +139,7 @@
   <xs:simpleType name="IfcGuid">
     <xs:restriction base="xs:string">
       <xs:length value="22" />
-      <xs:pattern value="[0-9,A-Z,a-z,_$]*" />
+      <xs:pattern value="[0-9A-Za-z_$]*" />
     </xs:restriction>
   </xs:simpleType>
   <xs:attributeGroup name="FileAttributes">


### PR DESCRIPTION
Closes #187

The following XML would validate against the updated definition:
```xml
<VisualizationInfo Guid="cc4dc1d9-8469-4780-b13e-d7a2b83806e9">
  <Components>
    <Visibility />
    <Coloring>
      <Color Color="FF00FF">
        <Component />
      </Color>
      <Color Color="ff00ff">
        <Component />
      </Color>
    </Coloring>
  </Components>
</VisualizationInfo>
```

Checked with: http://www.utilities-online.info/xsdvalidation/

However, I'm not sure if we need a comma there to separate the groups, e.g. I've now written it like this: `[0-9,A-Fa-f]`  
where in the `IfcGuid`, we have it like this: `[0-9,A-Z,a-z,_$]`

I don't think we need the additional commas to separate the ranges, but I couldn't find anything about the commas. In a regular expression, the commas should not be needed. They would actually lead to the comma being a valid character,

In fact, the online validator even says this is valid: `<Color Color="ff0,ff">`

So maybe we just remove the commas whereever they appear? 
CC @ykulbak @jasollien @pasi-paasiala