### PR TITLE
Bring Components back to VisualizationInfo (#239)

### DIFF
--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -7,13 +7,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="Components" minOccurs="0">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="Component" type="Component" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
+                <xs:element name="Components" type="Components" minOccurs="0" />
                 <xs:choice>
                     <xs:element name="OrthogonalCamera" type="OrthogonalCamera"/>
                     <xs:element name="PerspectiveCamera" type="PerspectiveCamera"/>


### PR DESCRIPTION
The components in VisualizationInfo need to refer to the Components containgin selection,
visibility, and coloring