### PR TITLE
Version.xsd : "VersionId" shall be "required"

### DIFF
--- a/Schemas/version.xsd
+++ b/Schemas/version.xsd
@@ -5,7 +5,7 @@
             <xs:sequence>
                 <xs:element name="DetailedVersion" type="xs:string" minOccurs="0"/>
             </xs:sequence>
-            <xs:attribute name="VersionId" type="xs:string"/>
+            <xs:attribute name="VersionId" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>


### PR DESCRIPTION
In version.xsd : VersionId attribute should be "required" since DetailedVersion is optional. Else both could be left empty.