### PR TITLE
Add display information

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+build.sh text eol=lf

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -27,7 +27,7 @@ The root of the BCF zip contains the following files.
 * extensions.xml
     - An XML file defining the extensions of a project. The schema for this file is extensions.xsd.
 * project.bcfp (optional)
-    - An XML file defining the details of a project. The schema for this file is project.xsd.
+    - An XML file defining the details and files_information of a project. The schema for this file is project.xsd.
 * documents.xml (optional)
     - An XML file defining the documents in a project. The schema for this file is documents.xsd.
 * bcf.version
@@ -71,11 +71,20 @@ Please note that the colon in the timezone offset is optional, so `+02:00` is eq
 
 To void ambiguity, this specification steps away from ISO 8601 on the topic of DateTime values with no timezone: The ISO 8601 says that DateTime values with no timezone designator are local times - **In BCF all DateTime values with no timezone designator are assumed to be in UTC**.
 
-## Project (.bcfp) file
+## Project information (project.bcfp file)
 
-The project file contains reference information about the project the topics belong to.
+The project information file contains details about the project and the files_information.
 
+There should be one entry per unique `File` found in `Markup`.`Header`s 
 
+ Attribute | Optional | Description |
+:-----------|:------------|:------------:
+ Project  |        No |     Project
+ FilesInformation  |        Yes |     List of `File information`
+
+### Project
+
+Project contains reference information about the project the topics belong to.
 
  Attribute | Optional | Description |
 :-----------|:------------|:------------:
@@ -89,18 +98,29 @@ The project file contains reference information about the project the topics bel
 Name | Yes | Name of the project.
 
 
-## Markup (.bcf) file
-The markup file contains textual information about the topic.
+### File information
 
-### Header
-Header node contains information about the IFC files relevant to this topic. 
-
-The "files" should be used to match which models to be opened when displaying the topic viewpoints.
+Consists of both human readable and machine readable information about the file.
 
 As IFC-files don't have an unique id, this matching might not be fully automated.
 Therefore the software importing the BCF file should give the user a possibility to match these files, with the internal models.
 
-Each File node has the following attributes:
+ Attribute | Optional | Description |
+:-----------|:------------|:------------:
+ File  |        No |     `File` - Machine readable information about the file
+ DisplayInformation  |        no |     List of `Display information` - Human readable information about the file
+
+### DisplayInformation
+
+Consists of human readable information about a file
+
+ Attribute | Optional | Description |
+:-----------|:------------|:------------:
+ FieldDisplayName  |        No |     The display name of the value
+ DisplayInformation  |        no |     The value
+
+### File
+Consists of properties being used to identify a `file`
 
  Attribute | Optional | Description |
 :-----------|:------------|:------------
@@ -115,6 +135,19 @@ In addition File has the following nodes:
 Filename | Yes | The BIM file related to this topic.
 Date | Yes | Date of the BIM file.
 Reference | Yes | URI to IfcFile. <br> IsExternal=false “..\example.ifc“ (within bcfzip) <br> IsExternal=true  “https://.../example.ifc“
+
+## Markup (.bcf) file
+The markup file contains textual information about the topic.
+
+### Header
+Header node contains information about the IFC files relevant to this topic. 
+
+The "files" should be used to match which models to be opened when displaying the topic viewpoints.
+The file should also be registered in `Files information` in `project.bcfp`
+
+Attribute | Optional | Description |
+:-----------|:------------|:------------
+ Files  |        Yes |     List of `File`
 
 ### Topic
 Topic node contains reference information of the topic. It has one required attribute, which is the topic GUID (`Guid`).

--- a/Schemas/markup.xsd
+++ b/Schemas/markup.xsd
@@ -118,20 +118,6 @@
         <xs:attribute name="TopicType" type="NonEmptyOrBlankString" use="required"/>
         <xs:attribute name="TopicStatus" type="NonEmptyOrBlankString" use="required"/>
     </xs:complexType>
-    <xs:complexType name="File">
-        <xs:sequence>
-            <xs:element name="Filename" type="NonEmptyOrBlankString" minOccurs="0"/>
-            <xs:element name="Date" type="xs:dateTime" minOccurs="0"/>
-            <!-- Reference (URL) of the file -->
-            <xs:element name="Reference" type="NonEmptyOrBlankString" minOccurs="0"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="FileAttributes"/>
-    </xs:complexType>
-    <xs:attributeGroup name="FileAttributes">
-        <xs:attribute name="IfcProject" type="IfcGuid" use="optional"/>
-        <xs:attribute name="IfcSpatialStructureElement" type="IfcGuid" use="optional"/>
-        <xs:attribute name="IsExternal" type="xs:boolean" default="true"/>
-    </xs:attributeGroup>
     <!-- Reference to a document inside of the topic folder or a url pointing to the web -->
     <xs:complexType name="DocumentReference">
         <xs:sequence>
@@ -165,10 +151,4 @@
         </xs:sequence>
         <xs:attribute name="Guid" type="Guid" use="required"/>
     </xs:complexType>
-    <xs:simpleType name="IfcGuid">
-        <xs:restriction base="xs:string">
-            <xs:length value="22"/>
-            <xs:pattern value="[0-9A-Za-z_$]*"/>
-        </xs:restriction>
-    </xs:simpleType>
 </xs:schema>

--- a/Schemas/project.xsd
+++ b/Schemas/project.xsd
@@ -5,6 +5,13 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="Project" type="Project"/>
+                <xs:element name="FilesInformation" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="FileInformation" type="FileInformation" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -13,5 +20,19 @@
             <xs:element name="Name" type="NonEmptyOrBlankString" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="ProjectId" type="NonEmptyOrBlankString" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="FileInformation">
+        <xs:sequence>
+            <xs:element name="DisplayInformation" type="DisplayInformation"/>
+            <xs:element name="File" type="File"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="DisplayInformation">
+        <xs:sequence>
+            <!-- Filename of the document with the file extension. Not used to store the file in the BCF -->
+            <xs:element name="FieldDisplayName" type="NonEmptyOrBlankString"/>
+            <!-- Human readable description of the document -->
+            <xs:element name="FieldDisplayValue" type="NonEmptyOrBlankString"/>
+        </xs:sequence>
     </xs:complexType>
 </xs:schema>

--- a/Schemas/shared-types.xsd
+++ b/Schemas/shared-types.xsd
@@ -5,10 +5,30 @@
             <xs:pattern value="[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="IfcGuid">
+        <xs:restriction base="xs:string">
+            <xs:length value="22"/>
+            <xs:pattern value="[0-9A-Za-z_$]*"/>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:simpleType name="NonEmptyOrBlankString">
         <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
             <xs:whiteSpace value="collapse"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="File">
+        <xs:sequence>
+            <xs:element name="Filename" type="NonEmptyOrBlankString" minOccurs="0"/>
+            <xs:element name="Date" type="xs:dateTime" minOccurs="0"/>
+            <!-- Reference (URL) of the file -->
+            <xs:element name="Reference" type="NonEmptyOrBlankString" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="FileAttributes"/>
+    </xs:complexType>
+    <xs:attributeGroup name="FileAttributes">
+        <xs:attribute name="IfcProject" type="IfcGuid" use="optional"/>
+        <xs:attribute name="IfcSpatialStructureElement" type="IfcGuid" use="optional"/>
+        <xs:attribute name="IsExternal" type="xs:boolean" default="true"/>
+    </xs:attributeGroup>
 </xs:schema>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.0.2" />
-    <PackageDownload Include="bcf-tool.CommandLine" Version="[1.0.7]" />
+    <PackageDownload Include="bcf-tool.CommandLine" Version="[1.0.9]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add optional "files_information" in Project info, according to BCF-API v3.0. 

Question: Does files_information belong under extensions or project?

"files" in markup header is kept as is. 

