### PR TITLE
Fix Bitmaps element of v2.1 in visinfo.xsd

### DIFF
--- a/Schemas/visinfo.xsd
+++ b/Schemas/visinfo.xsd
@@ -25,7 +25,7 @@
 					</xs:complexType>
 				</xs:element>
 				<!-- ISG Jira issue BCF-17: Add support for text in the viewpoints -->
-				<xs:element name="Bitmap" minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="Bitmaps" minOccurs="0" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="Bitmap" type="BitmapFormat"/>


### PR DESCRIPTION
The Bitmaps element in v2.1 is wrong and needs to be fixed.

Unfortunately there is not a single v2.1 test case that has this optional element set.