### PR TITLE
Fix BCF logo in bcf 2.1 readme

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,5 +1,5 @@
 	# BIM Collaboration Format v2.1 Technical Documentation
-![BCF](https://github.com/BuildingSMART/BCF/blob/master/Icons/BCFicon128.png?raw=true "The BCF logo")
+![BCF](https://raw.githubusercontent.com/buildingSMART/BCF-XML/master/Icons/BCFicon128.png "The BCF logo")
 
 Authors:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 BCF-XML: File-Based Implementation of BIM Collaboration Format
 ===
 
-![BCF](https://github.com/BuildingSMART/BCF/blob/master/Icons/BCFicon128.png?raw=true "The BCF logo")
+![BCF](https://raw.githubusercontent.com/buildingSMART/BCF-XML/master/Icons/BCFicon128.png "The BCF logo")
 
 Public repo for work on the file-based Building Collaboration Format standard BCF 2.0.
 Read all about the technical documentation on https://github.com/BuildingSMART/BCF-XML/tree/master/Documentation 


### PR DESCRIPTION
Accessing raw urls by using `?raw=true` seems to be deprecated by github. Change is basically the same as #355 but for v.2.1.